### PR TITLE
use jdk8

### DIFF
--- a/shippable.yml
+++ b/shippable.yml
@@ -1,5 +1,6 @@
 language: java
-
+jdk:
+  - oraclejdk8
 build:
  ci:
   - mkdir -p $HOME/bin


### PR DESCRIPTION
Shippable by default uses jdk7 which was causing an error due to a dependency.